### PR TITLE
Move dynamic memory settings into conditional block

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -97,11 +97,11 @@ if (!$switchname) {
 
 Connect-VMNetworkAdapter -VMNetworkAdapter (Get-VMNetworkAdapter -VM $vmConfig.VM) -SwitchName $switchname
 Set-VM -VM $vmConfig.VM -NewVMName $vm_name -MemoryStartupBytes $MemoryStartupBytes
-Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -MemoryMaximumBytes $MemoryMaximumBytes
 Set-VM -VM $vmConfig.VM -ErrorAction "Stop" -ProcessorCount $processors
 
 If ($dynamicmemory) {
     Set-VM -VM $vmConfig.VM -DynamicMemory
+    Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -MemoryMaximumBytes $MemoryMaximumBytes
 } else {
     Set-VM -VM $vmConfig.VM -StaticMemory    
 }


### PR DESCRIPTION
Importing a vmcx vm I got this error - it seems that dynamic memory must be on prior to setting dynamic memory related settings

Script: import_vm_vmcx.ps1
Error:

Set-VM : Dynamic and static memory settings cannot be specified together. To set maximum memory, minimum memory and
buffer settings, turn on Dynamic Memory as well.
At C:\vagrant\plugins\providers\hyperv\scripts\import_vm_vmcx.ps1:100 char:1
+ Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -Memo ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-VM], VirtualizationException
    + FullyQualifiedErrorId : InvalidParameter,Microsoft.HyperV.PowerShell.Commands.SetVM
